### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 pytest-django-casperjs
 ======================
 
-.. image:: https://pypip.in/v/pytest-django-casperjs/badge.png
+.. image:: https://img.shields.io/pypi/v/pytest-django-casperjs.svg
     :target: https://pypi.python.org/pypi/pytest-django-casperjs
     :alt: Latest PyPI version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pytest-django-casperjs))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pytest-django-casperjs`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.